### PR TITLE
`images`, `image` コマンドを実装

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -89,3 +89,25 @@ let uc = newUtliemCli()
 echo uc.image.list()
 uc.image.create("image_1")
 ```
+
+## イメージファイル (image.aviutliem.yml) の中身の例
+
+```yaml
+image_name: image_1
+
+base:
+  aviutl_version: 1.10
+  exedit_version: 0.92
+
+plugins:
+  - id: hoge
+    version: 1.2.0
+  - id: fuga
+    version: 3.4
+
+scripts:
+  - id: piyo
+    version: 0.1.7
+  - id: hogera
+    version: 6.12.9
+```

--- a/notes.md
+++ b/notes.md
@@ -66,10 +66,10 @@ utliem images import "image_1.image.aviutliem.json"
 utliem images export "image_1" --path "image_1.image.aviutliem.json"
 utliem images delete "image_1"
 utliem image "image_1" base
-utliem image "image_1" plugin add "hoge:1.2.0"
-utliem image "image_1" plugin ls
-utliem image "image_1" plugin list
-utliem image "image_1" plugin delete "hoge"
+utliem image "image_1" plugins add "hoge:1.2.0"
+utliem image "image_1" plugins ls
+utliem image "image_1" plugins list
+utliem image "image_1" plugins delete "hoge"
 ```
 
 ### container

--- a/notes.md
+++ b/notes.md
@@ -61,11 +61,15 @@ utliem -h
 utliem image
 utliem image ls
 utliem image list
-utliem image create --name "image_1"
-utliem image import "image_1.image.aviutliem.json"
-utliem image export "image_1" --path "image_1.image.aviutliem.json"
-utliem image delete "image_1"
-utliem image update "image_1" --path "image_1_new.image.aviutliem.json"
+utliem images create --name "image_1"
+utliem images import "image_1.image.aviutliem.json"
+utliem images export "image_1" --path "image_1.image.aviutliem.json"
+utliem images delete "image_1"
+utliem image "image_1" base
+utliem image "image_1" plugin add "hoge:1.2.0"
+utliem image "image_1" plugin ls
+utliem image "image_1" plugin list
+utliem image "image_1" plugin delete "hoge"
 ```
 
 ### container

--- a/src/libs/types.nim
+++ b/src/libs/types.nim
@@ -1,0 +1,17 @@
+type Base = object
+  aviutl_version*: string
+  exedit_version*: string
+
+type Plugin* = object
+  id*: string
+  version*: string
+
+type Script = object
+  id*: string
+  version*: string
+
+type ImageYaml* = object
+  image_name*: string
+  base*: Base
+  plugins*: seq[Plugin]
+  scripts*: seq[Script]

--- a/src/libs/types.nim
+++ b/src/libs/types.nim
@@ -1,3 +1,10 @@
+import
+  streams
+
+import
+  yaml/serialization
+
+
 type Base = object
   aviutl_version*: string
   exedit_version*: string
@@ -15,3 +22,20 @@ type ImageYaml* = object
   base*: Base
   plugins*: seq[Plugin]
   scripts*: seq[Script]
+
+
+type YamlFile = object of RootObj
+  filePath*: string
+
+proc load[T](yamlFile: YamlFile, obj: var T): T =
+  let fileStream = newFileStream(yamlFile.filePath)
+  fileStream.load(obj)
+  fileStream.close
+
+type ImageYamlFile* = object of YamlFile
+  discard
+
+proc load*(imageYamlFile: ImageYamlFile): ImageYaml =
+  var imageYaml: ImageYaml
+  discard imageYamlFile.load(imageYaml)
+  return imageYaml

--- a/src/libs/types.nim
+++ b/src/libs/types.nim
@@ -32,6 +32,11 @@ proc load[T](yamlFile: YamlFile, obj: var T): T =
   fileStream.load(obj)
   fileStream.close
 
+proc updateY[T](yamlFile: YamlFile, obj: T): T =
+  let fileStream = newFileStream(yamlFile.filePath, fmWrite)
+  obj.dump(fileStream)
+  fileStream.close()
+
 type ImageYamlFile* = object of YamlFile
   discard
 
@@ -39,3 +44,6 @@ proc load*(imageYamlFile: ImageYamlFile): ImageYaml =
   var imageYaml: ImageYaml
   discard imageYamlFile.load(imageYaml)
   return imageYaml
+
+proc update*(imageYamlFile: ImageYamlFile, imageYaml: ImageYaml): ImageYaml =
+  discard imageYamlFile.updateY(imageYaml)

--- a/src/libs/types.nim
+++ b/src/libs/types.nim
@@ -30,7 +30,7 @@ type YamlFile = object of RootObj
 proc load[T](yamlFile: YamlFile, obj: var T): T =
   let fileStream = newFileStream(yamlFile.filePath)
   fileStream.load(obj)
-  fileStream.close
+  fileStream.close()
 
 proc updateY[T](yamlFile: YamlFile, obj: T): T =
   let fileStream = newFileStream(yamlFile.filePath, fmWrite)

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -1,5 +1,12 @@
 import
-  os
+  os,
+  streams
+
+import
+  yaml/serialization
+
+import
+  types
 
 
 type UtliemCli = object
@@ -8,6 +15,13 @@ type UtliemCli = object
 type UcImages = object
   utliemCli: ref UtliemCli
   imagesDirPath: string
+
+type UcImage = object
+  utliemCli: ref UtliemCli
+  imageDirPath: string
+
+type UcPlugins = object
+  ucImage: UcImage
 
 type UcContainer = object
   discard
@@ -31,3 +45,18 @@ proc list*(i: UcImages): seq[string] =
 
 proc delete*(i: UcImages, name: string) =
   discard
+
+proc image*(uc: ref UtliemCli, imageName: string): UcImage =
+  result.utliemCli = uc
+  result.imageDirPath = uc.appDirectoryPath / "images" / imageName
+
+proc plugins*(i: UcImage): UcPlugins =
+  result.ucImage = i
+
+proc list*(p: UcPlugins): seq[Plugin] =
+  var imageYaml: ImageYaml
+  var s = newFileStream(p.ucImage.imageDirPath / "image.aviutliem.yaml")
+  # echo s.readAll
+  s.load(imageYaml)
+  s.close
+  return imageYaml.plugins

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -19,6 +19,8 @@ type UcImages = object
 type UcImage = object
   utliemCli: ref UtliemCli
   imageDirPath: string
+  imageFileName: string
+  imageFilePath: string
 
 type UcPlugins = object
   ucImage: UcImage
@@ -49,13 +51,15 @@ proc delete*(i: UcImages, name: string) =
 proc image*(uc: ref UtliemCli, imageName: string): UcImage =
   result.utliemCli = uc
   result.imageDirPath = uc.appDirectoryPath / "images" / imageName
+  result.imageFileName = "image.aviutliem.yaml"
+  result.imageFilePath = result.imageDirPath / result.imageFileName
 
 proc plugins*(i: UcImage): UcPlugins =
   result.ucImage = i
 
 proc list*(p: UcPlugins): seq[Plugin] =
   var imageYaml: ImageYaml
-  var s = newFileStream(p.ucImage.imageDirPath / "image.aviutliem.yaml")
+  var s = newFileStream(p.ucImage.imageFilePath)
   # echo s.readAll
   s.load(imageYaml)
   s.close

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -58,3 +58,9 @@ proc list*(p: UcPlugins): seq[Plugin] =
     imageYamlFile = ImageYamlFile(filePath: p.ucImage.imageFilePath)
     imageYaml = imageYamlFile.load
   return imageYaml.plugins
+
+proc add*(p: UcPlugins, plugin: Plugin) =
+  let imageYamlFile = ImageYamlFile(filePath: p.ucImage.imageFilePath)
+  var imageYaml = imageYamlFile.load()
+  imageYaml.plugins.add(plugin)
+  discard imageYamlFile.update(imageYaml)

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -1,9 +1,5 @@
 import
-  os,
-  streams
-
-import
-  yaml/serialization
+  os
 
 import
   types
@@ -58,9 +54,7 @@ proc plugins*(i: UcImage): UcPlugins =
   result.ucImage = i
 
 proc list*(p: UcPlugins): seq[Plugin] =
-  var imageYaml: ImageYaml
-  var s = newFileStream(p.ucImage.imageFilePath)
-  # echo s.readAll
-  s.load(imageYaml)
-  s.close
+  let
+    imageYamlFile = ImageYamlFile(filePath: p.ucImage.imageFilePath)
+    imageYaml = imageYamlFile.load
   return imageYaml.plugins

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -26,7 +26,8 @@ proc image*(uc: ref UtliemCli): UcImage =
   result.imagesDirPath = uc.appDirectoryPath / "images"
 
 proc list*(i: UcImage): seq[string] =
-  i.imagesDirPath.listDirectories
+  for fd in i.imagesDirPath.listDirectories:
+    result.add(fd.splitPath.tail)
 
 proc delete*(i: UcImage, name: string) =
   discard

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -64,3 +64,16 @@ proc add*(p: UcPlugins, plugin: Plugin) =
   var imageYaml = imageYamlFile.load()
   imageYaml.plugins.add(plugin)
   discard imageYamlFile.update(imageYaml)
+
+proc delete*(p: UcPlugins, pluginId: string) =
+  let imageYamlFile = ImageYamlFile(filePath: p.ucImage.imageFilePath)
+  var imageYaml = imageYamlFile.load()
+
+  var remainedPlugins: seq[Plugin] = @[]
+  for i, plugin in imageYaml.plugins:
+    if plugin.id != pluginId:
+      remainedPlugins.add(plugin)
+
+  imageYaml.plugins = remainedPlugins
+
+  discard imageYamlFile.update(imageYaml)

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -56,7 +56,7 @@ proc plugins*(i: UcImage): UcPlugins =
 proc list*(p: UcPlugins): seq[Plugin] =
   let
     imageYamlFile = ImageYamlFile(filePath: p.ucImage.imageFilePath)
-    imageYaml = imageYamlFile.load
+    imageYaml = imageYamlFile.load()
   return imageYaml.plugins
 
 proc add*(p: UcPlugins, plugin: Plugin) =

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -5,7 +5,7 @@ import
 type UtliemCli = object
   appDirectoryPath: string
 
-type UcImage = object
+type UcImages = object
   utliemCli: ref UtliemCli
   imagesDirPath: string
 
@@ -21,13 +21,13 @@ proc listDirectories(dirPath: string): seq[string] =
   for fd in walkDir(dirPath):
     result.add(fd.path)
 
-proc image*(uc: ref UtliemCli): UcImage =
+proc images*(uc: ref UtliemCli): UcImages =
   result.utliemCli = uc
   result.imagesDirPath = uc.appDirectoryPath / "images"
 
-proc list*(i: UcImage): seq[string] =
+proc list*(i: UcImages): seq[string] =
   for fd in i.imagesDirPath.listDirectories:
     result.add(fd.splitPath.tail)
 
-proc delete*(i: UcImage, name: string) =
+proc delete*(i: UcImages, name: string) =
   discard

--- a/src/main.nim
+++ b/src/main.nim
@@ -49,4 +49,8 @@ proc container(args: seq[string]) =
 
 when isMainModule:
   import cligen
-  dispatchMulti([main.images], [main.image], [main.container])
+  dispatchMulti(
+    [main.images],
+    [main.image],
+    [main.container]
+  )

--- a/src/main.nim
+++ b/src/main.nim
@@ -46,7 +46,7 @@ proc image(args: seq[string]) =
               version: pluginVersion
             )
           uc.image(imageName).plugins.add(plugin)
-        of "delete":
+        of "del", "delete":
           echo "plugins delete"
           let pluginId = options[1]
           uc.image(imageName).plugins.delete(pluginId)

--- a/src/main.nim
+++ b/src/main.nim
@@ -50,6 +50,8 @@ proc image(args: seq[string]) =
           echo "plugins delete"
           let pluginId = options[1]
           uc.image(imageName).plugins.delete(pluginId)
+        else:
+          echo "unknown command"
     else:
       echo "unknown command"
 

--- a/src/main.nim
+++ b/src/main.nim
@@ -20,6 +20,21 @@ proc images(args: seq[string]) =
     else:
       echo "unknown command"
 
+proc image(args: seq[string]) =
+  echo "image command"
+  let
+    imageName = args[0]
+    subcommand = args[1]
+    options = args[2..^1]
+  case subcommand:
+    of "plugins":
+      case options[0]:
+        of "ls", "list":
+          echo "plugins list"
+          echo uc.image(imageName).plugins.list
+    else:
+      echo "unknown command"
+
 proc container(args: seq[string]) =
   echo "container command"
   let
@@ -34,4 +49,4 @@ proc container(args: seq[string]) =
 
 when isMainModule:
   import cligen
-  dispatchMulti([main.images], [main.container])
+  dispatchMulti([main.images], [main.image], [main.container])

--- a/src/main.nim
+++ b/src/main.nim
@@ -1,21 +1,21 @@
 import
   libs/commands/containers,
-  libs/commands/images,
+  # libs/commands/images,
   libs/utliem_cli
 
 
 let uc = newUtliemCli("app")
 
 
-proc image(args: seq[string]) =
-  echo "image command"
+proc images(args: seq[string]) =
+  echo "images command"
   let
     subcommand = args[0]
     options = args[1..^1]
   case subcommand:
     of "ls", "list":
       # images.list(options)
-      for image in uc.image.list:
+      for image in uc.images.list:
         echo image
     else:
       echo "unknown command"
@@ -34,4 +34,4 @@ proc container(args: seq[string]) =
 
 when isMainModule:
   import cligen
-  dispatchMulti([main.image], [main.container])
+  dispatchMulti([main.images], [main.container])

--- a/src/main.nim
+++ b/src/main.nim
@@ -1,6 +1,10 @@
 import
+  strutils
+
+import
   libs/commands/containers,
   # libs/commands/images,
+  libs/types,
   libs/utliem_cli
 
 
@@ -32,6 +36,16 @@ proc image(args: seq[string]) =
         of "ls", "list":
           echo "plugins list"
           echo uc.image(imageName).plugins.list
+        of "add":
+          echo "plugins add"
+          let
+            pluginId = options[1].split(":")[0]
+            pluginVersion = options[1].split(":")[1]
+            plugin = Plugin(
+              id: pluginId,
+              version: pluginVersion
+            )
+          uc.image(imageName).plugins.add(plugin)
     else:
       echo "unknown command"
 

--- a/src/main.nim
+++ b/src/main.nim
@@ -46,6 +46,10 @@ proc image(args: seq[string]) =
               version: pluginVersion
             )
           uc.image(imageName).plugins.add(plugin)
+        of "delete":
+          echo "plugins delete"
+          let pluginId = options[1]
+          uc.image(imageName).plugins.delete(pluginId)
     else:
       echo "unknown command"
 

--- a/src/main.nim
+++ b/src/main.nim
@@ -15,7 +15,8 @@ proc image(args: seq[string]) =
   case subcommand:
     of "ls", "list":
       # images.list(options)
-      echo uc.image.list
+      for image in uc.image.list:
+        echo image
     else:
       echo "unknown command"
 


### PR DESCRIPTION
# 概要

## Features
- `images [ls | list]` コマンドを実装
- `image <image_name> plugins` コマンドを実装
  - `plugins [ls | list]` コマンドを実装
    - イメージ内のプラグイン一覧を表示するコマンド
  - `plugins add` コマンドを実装
    - イメージ内のプラグインを追加するコマンド
  - `plugins [del | delete]` コマンドを実装
    - イメージ内のプラグインを削除するコマンド

## Docs
- イメージファイルの中身の例を追加 (77d37c3fef3ecefe26cc28ecb3aa620d10a30b5a)
- 一部の `image` コマンドを `images` コマンドに移動

## Styles
- コマンドのディスパッチ部分で改行を挿入することにより差分が見やすくなるようにした (77d37c3fef3ecefe26cc28ecb3aa620d10a30b5a)