### PR TITLE
`images` コマンドのサブコマンドを実装&追加, リファクタリング

### DIFF
--- a/src/libs/procs.nim
+++ b/src/libs/procs.nim
@@ -4,6 +4,8 @@ import
 
 proc sanitizeFileOrDirName*(s: string): string =
   result = s
-  const replacingTargets = ["..", "/", "\\"]
+  const replacingTargets = [
+    "..", "/", "\\", ":", "*", "?", "\"", "<", ">", "|"
+  ]
   for target in replacingTargets:
     result = result.replace(target, "")

--- a/src/libs/procs.nim
+++ b/src/libs/procs.nim
@@ -1,0 +1,9 @@
+import
+  strutils
+
+
+proc sanitizeFileOrDirName*(s: string): string =
+  result = s
+  const replacingTargets = ["..", "/", "\\"]
+  for target in replacingTargets:
+    result = result.replace(target, "")

--- a/src/libs/templates.nim
+++ b/src/libs/templates.nim
@@ -1,0 +1,9 @@
+import
+  types
+
+
+type YamlTemplates* = object
+  imageYaml*: ImageYaml
+
+
+let yamlTemplates* = YamlTemplates()

--- a/src/libs/types.nim
+++ b/src/libs/types.nim
@@ -1,4 +1,4 @@
-type Base = object
+type Base* = object
   aviutl_version*: string
   exedit_version*: string
 

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -57,9 +57,15 @@ proc create*(ucImages: UcImages, imageName: string) =
     imageYamlFile = ImageYamlFile(filePath: newImageFilePath)
   discard imageYamlFile.update(yamlTemplates.imageYaml)
 
+proc delete*(ucImages: UcImages, imageName: string) =
+  let
+    sanitizedImageName = imageName.sanitizeFileOrDirName
+    targetImageDirPath = ucImages.imagesDirPath / sanitizedImageName
+  try:
+    removeDir(targetImageDirPath, checkDir = true)
+  except OSError:
+    raise newException(ValueError, fmt"Image named '{sanitizedImageName}' does not exist")
 
-proc delete*(ucImages: UcImages, name: string) =
-  discard
 
 proc image*(uc: ref UtliemCli, imageName: string): UcImage =
   result.utliemCli = uc

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -1,7 +1,9 @@
 import
-  os
+  os,
+  strformat
 
 import
+  templates,
   types,
   yaml_file
 
@@ -41,6 +43,17 @@ proc images*(uc: ref UtliemCli): UcImages =
 proc list*(ucImages: UcImages): seq[string] =
   for fileOrDir in ucImages.imagesDirPath.listDirectories:
     result.add(fileOrDir.splitPath.tail)
+
+proc create*(ucImages: UcImages, imageName: string) =
+  let newImageDirPath = ucImages.imagesDirPath / imageName
+  if dirExists(newImageDirPath):
+    raise newException(ValueError, fmt"Image named '{imageName}' already exists")
+  createDir newImageDirPath
+  let
+    newImageFilePath = newImageDirPath / "image.aviutliem.yaml"
+    imageYamlFile = ImageYamlFile(filePath: newImageFilePath)
+  discard imageYamlFile.update(yamlTemplates.imageYaml)
+
 
 proc delete*(ucImages: UcImages, name: string) =
   discard

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -3,6 +3,7 @@ import
   strformat
 
 import
+  procs,
   templates,
   types,
   yaml_file
@@ -45,9 +46,11 @@ proc list*(ucImages: UcImages): seq[string] =
     result.add(fileOrDir.splitPath.tail)
 
 proc create*(ucImages: UcImages, imageName: string) =
-  let newImageDirPath = ucImages.imagesDirPath / imageName
+  let
+    sanitizedImageName = imageName.sanitizeFileOrDirName
+    newImageDirPath = ucImages.imagesDirPath / sanitizedImageName
   if dirExists(newImageDirPath):
-    raise newException(ValueError, fmt"Image named '{imageName}' already exists")
+    raise newException(ValueError, fmt"Image named '{sanitizedImageName}' already exists")
   createDir newImageDirPath
   let
     newImageFilePath = newImageDirPath / "image.aviutliem.yaml"

--- a/src/libs/utliem_cli.nim
+++ b/src/libs/utliem_cli.nim
@@ -38,8 +38,8 @@ proc images*(uc: ref UtliemCli): UcImages =
   result.utliemCli = uc
   result.imagesDirPath = uc.appDirPath / "images"
 
-proc list*(i: UcImages): seq[string] =
-  for fileOrDir in i.imagesDirPath.listDirectories:
+proc list*(ucImages: UcImages): seq[string] =
+  for fileOrDir in ucImages.imagesDirPath.listDirectories:
     result.add(fileOrDir.splitPath.tail)
 
 proc delete*(ucImages: UcImages, name: string) =

--- a/src/main.nim
+++ b/src/main.nim
@@ -21,6 +21,10 @@ proc images(args: seq[string]) =
       # images.list(options)
       for image in uc.images.list:
         echo image
+    of "create":
+      echo "images create"
+      let imageName = options[0]
+      uc.images.create(imageName)
     else:
       echo "unknown command"
 

--- a/src/main.nim
+++ b/src/main.nim
@@ -25,6 +25,10 @@ proc images(args: seq[string]) =
       echo "images create"
       let imageName = options[0]
       uc.images.create(imageName)
+    of "del", "delete":
+      echo "images delete"
+      let imageName = options[0]
+      uc.images.delete(imageName)
     else:
       echo "unknown command"
 


### PR DESCRIPTION
# 概要

## Feats
- images-command
  - [createコマンドを実装&追加](https://github.com/lafixier/aviutliem-cli/commit/2e65c9f88809d132c95f2a51943da7e30c7015e2)
  - [deleteコマンドを実装&追加](https://github.com/lafixier/aviutliem-cli/commit/bf65e7907bbe03ad2635b75f95813f7bf55a2391)

## Refactor
- [(utliem_cli.nim): 変数名を省略せずに表記](https://github.com/lafixier/aviutliem-cli/commit/638dff3cfbeb1a7d69041503969ef07ba61d720e)